### PR TITLE
Add suite2p to Analysis Software For Imaging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ Contributions are VERY welcome!
   including conversion from and between many file
   formats](https://nipy.org/nibabel/)
 - [NiMARE - NiMARE is a Python package for neuroimaging meta-analyses](https://nimare.readthedocs.io/en/latest/)
+- [suite2p - Fast, scalable calcium imaging pipeline for cell detection (ROI extraction), neuropil correction, signal extraction, and spike deconvolution from two-photon microscopy data](https://github.com/MouseLand/suite2p)
 - [supereeg - Sparse ECoG analysis](http://supereeg.readthedocs.io/en/latest/)
 - [TrakEM2 - Morphological image (histological staining) data mining and analysis
   plugin](https://syn.mrc-lmb.cam.ac.uk/acardona/INI-2008-2011/trakem2.html) for use as a [plugin for ImageJ](https://imagej.net/plugins/trakem2/) including as part of the [Fiji distribution](https://fiji.sc/)
 - [TREES - MATLAB toolbox for analyzing neuron
   microscopy](http://www.treestoolbox.org/)
-- [suite2p - Fast, scalable calcium imaging pipeline for cell detection (ROI extraction), neuropil correction, signal extraction, and spike deconvolution from two-photon microscopy data](https://github.com/MouseLand/suite2p)
 - [V-NeuroStack - 3D time stacks for finding patterns in spontaneous activity of
   neurons in mouse brain slices](https://www.evl.uic.edu/entry.php?id=2479)
 


### PR DESCRIPTION
Adds [suite2p](https://github.com/MouseLand/suite2p) to the "Analysis Software For Imaging" section, alphabetically before V-NeuroStack.

suite2p is a widely adopted open-source Python pipeline for processing two-photon calcium imaging data. It performs cell detection (ROI extraction), neuropil correction, signal extraction, and spike deconvolution. Developed at the MouseLand lab (Janelia/UCL), it is standard tooling in systems neuroscience labs for analyzing population activity from fluorescence imaging. 431+ GitHub stars, active development (last commit March 2026).

It complements the existing CaImAn entry and fills a gap in the calcium imaging coverage of this section.