### PR TITLE
Add Kilosort to Analysis Software For Electrophysiology section

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Contributions are VERY welcome!
   operations](http://neuralensemble.org/elephant/)
     - Elephant is the direct successor to [Neurotools](http://neuralensemble.org/NeuroTools/)
     - Elephant can consume electrophysiology data loaded by [Neo](http://neuralensemble.org/neo/)
+- [Kilosort - GPU-accelerated spike sorting for large-scale extracellular recordings, widely used with Neuropixels probes](https://github.com/MouseLand/Kilosort)
 - [Neo - Python library for enabling interoperability of electrophysiological
   data, including conversion from proprietary file
   formats](http://neuralensemble.org/neo/)
@@ -117,7 +118,6 @@ Contributions are VERY welcome!
 - [Pynapple - "PYthon Neural Analysis Package" for neurophysiological data analysis](https://github.com/pynapple-org/pynapple)
 - [Spike Sorting Software - VERY good comparison of different spike sorting
   software capabilities](https://simonster.github.io/SpikeSortingSoftware/)
-- [Kilosort - GPU-accelerated spike sorting for large-scale extracellular recordings, widely used with Neuropixels probes](https://github.com/MouseLand/Kilosort)
 - [SpikeInterface - Spike sorting analysis specifically made for compatibility
   between different sorting algorithms, part of the Open Ephys project](https://open-ephys.org/spikeinterface)
 - [SpykeViewer - Analysis software for spikes of electrophysiological data](http://neuralensemble.org/SpykeViewer/)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Contributions are VERY welcome!
 - [Pynapple - "PYthon Neural Analysis Package" for neurophysiological data analysis](https://github.com/pynapple-org/pynapple)
 - [Spike Sorting Software - VERY good comparison of different spike sorting
   software capabilities](https://simonster.github.io/SpikeSortingSoftware/)
+- [Kilosort - GPU-accelerated spike sorting for large-scale extracellular recordings, widely used with Neuropixels probes](https://github.com/MouseLand/Kilosort)
 - [SpikeInterface - Spike sorting analysis specifically made for compatibility
   between different sorting algorithms, part of the Open Ephys project](https://open-ephys.org/spikeinterface)
 - [SpykeViewer - Analysis software for spikes of electrophysiological data](http://neuralensemble.org/SpykeViewer/)


### PR DESCRIPTION
Adds [Kilosort](https://github.com/MouseLand/Kilosort) to the "Analysis Software For Electrophysiology" section, between the spike sorting comparison page and SpikeInterface.

Kilosort is the dominant GPU-accelerated spike sorting package in systems neuroscience, particularly for processing high-channel-count recordings from Neuropixels probes. Developed at the MouseLand lab, it is cited in thousands of neuroscience publications and is the standard preprocessing step before downstream analysis with tools like the Spike Sorting comparison site already listed. 593+ GitHub stars, active development (last commit January 2026).

It complements the existing SpikeInterface entry — SpikeInterface provides a unified wrapper API across multiple sorters including Kilosort; listing Kilosort directly gives readers the primary reference for the algorithm itself.