### PR TITLE
Add DeepLabCut to Other Analysis Software section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Contributions are VERY welcome!
 ##### Other Analysis Software
 
 - [bctnet - Brain Connectivity Toolbox for complex-network analysis](https://github.com/brainlife/BCT)
+- [DeepLabCut - Markerless pose estimation for quantifying behavior and movement kinematics in neuroscience experiments, using transfer learning from ImageNet-pretrained networks](https://github.com/DeepLabCut/DeepLabCut)
 - [Geppetto - Web-based, open-source visualization platform for computational
   biology](http://www.geppetto.org/)
 - [NeuronUnit - Data-driven model validation for


### PR DESCRIPTION
Adds [DeepLabCut](https://github.com/DeepLabCut/DeepLabCut) to the "Other Analysis Software" section, alphabetically between bctnet and Geppetto.

DeepLabCut is a standard Python package for markerless pose estimation in neuroscience behavioral experiments. It uses transfer learning from ImageNet-pretrained CNNs to track body part positions across video frames without physical markers, enabling quantification of movement kinematics, gait, and behavioral states. Developed at the Mathis Lab (EPFL), it has 5,500+ GitHub stars, is published in Nature Neuroscience, and is used in labs worldwide. Last commit February 2026.

Behavioral quantification is a core part of the computational neuroscience workflow — DeepLabCut fills a gap in the "Other Analysis Software" section, which currently covers connectivity and visualization tools but not movement/behavior analysis.